### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/shadanan/mediar/compare/v0.1.0...v0.1.1) - 2025-12-28
+
+### Other
+
+- Enable release-plz ([#19](https://github.com/shadanan/mediar/pull/19))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mediar"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mediar"
 description = "Rename and move media files using metadata from TMDB"
 readme = "README.md"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Shad Sharma <shadanan@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mediar`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/shadanan/mediar/compare/v0.1.0...v0.1.1) - 2025-12-28

### Other

- Enable release-plz ([#19](https://github.com/shadanan/mediar/pull/19))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).