### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/shadanan/mediar/compare/v0.1.1...v0.1.2) - 2025-12-28
+
+### Other
+
+- *(deps)* update rust crate serde_json to v1.0.148 ([#23](https://github.com/shadanan/mediar/pull/23))
+- Update readme with current installation instructions ([#26](https://github.com/shadanan/mediar/pull/26))
+- Improve episode ID detection when metadata exists ([#25](https://github.com/shadanan/mediar/pull/25))
+- Configure Renovate ([#21](https://github.com/shadanan/mediar/pull/21))
+
 ## [0.1.1](https://github.com/shadanan/mediar/compare/v0.1.0...v0.1.1) - 2025-12-28
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mediar"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mediar"
 description = "Rename and move media files using metadata from TMDB"
 readme = "README.md"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Shad Sharma <shadanan@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `mediar`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/shadanan/mediar/compare/v0.1.1...v0.1.2) - 2025-12-28

### Other

- *(deps)* update rust crate serde_json to v1.0.148 ([#23](https://github.com/shadanan/mediar/pull/23))
- Update readme with current installation instructions ([#26](https://github.com/shadanan/mediar/pull/26))
- Improve episode ID detection when metadata exists ([#25](https://github.com/shadanan/mediar/pull/25))
- Configure Renovate ([#21](https://github.com/shadanan/mediar/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).